### PR TITLE
Adding code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ cache:
     - node_modules
 
 env:
-  - EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-beta
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-beta
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH

--- a/addon/components/ui-autocomplete-field.js
+++ b/addon/components/ui-autocomplete-field.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+export default Ember.TextField.extend({
+  bubbles: true,
+
+  focusIn() {
+    this.sendAction('open');
+  },
+
+  keyDown(e) {
+    if (e.keyCode === 40 || e.keyCode === 38 || e.keyCode === 13) {
+      this.sendAction('open');
+      e.preventDefault();
+    }
+  },
+
+  didLoseKeyResponder(){}
+});

--- a/addon/components/ui-autocomplete.js
+++ b/addon/components/ui-autocomplete.js
@@ -1,0 +1,71 @@
+import Ember from 'ember';
+import layout from '../templates/components/ui-autocomplete';
+import OptionListAriaMixin from 'ui-option-list/mixins/option-list-aria';
+
+const { Component, computed, generateGuid, observer } = Ember;
+
+export default Component.extend(OptionListAriaMixin, {
+  layout: layout,
+  fieldComponent: 'ui-autocomplete-field',
+
+  classNames: ['ff-autocomplete'],
+
+  attachment: 'top left',
+  targetAttachment: 'bottom left',
+
+  'show-placeholder-as-option': false,
+
+  componentId: computed(function() {
+    return generateGuid();
+  }),
+
+  componentSelector: computed('componentId', function() {
+    return `#${this.get('componentId')}`;
+  }),
+
+  selectedValues: computed(function() {
+    return Ember.A();
+  }),
+
+  valueDidChange: observer('value', function() {
+    const selectedValues = this.get('selectedValues');
+    const value = this.get('value');
+
+    selectedValues.clear();
+
+    if (value) {
+      selectedValues.pushObject(value);
+    }
+  }),
+
+  focusOut() {
+    if (!this.get('selectWillChange')) {
+      this.send('close');
+    }
+  },
+
+  actions: {
+    open() {
+      this.set('isOpen', true);
+
+      Ember.run.next(() => {
+        Ember.$('.ff-option-list').on('mousedown.ui-autocomplete', () => {
+          this.set('selectWillChange', true);
+        });
+      });
+    },
+
+    close() {
+      Ember.$('.ff-option-list').off('mousedown.ui-autocomplete');
+      this.set('selectWillChange', false);
+
+      this.set('isOpen', false);
+    },
+
+    selectItem(value) {
+      this.set('value', value);
+      this.sendAction('on-select', value);
+      this.send('close');
+    }
+  }
+});

--- a/addon/templates/components/ui-autocomplete-field.hbs
+++ b/addon/templates/components/ui-autocomplete-field.hbs
@@ -1,0 +1,5 @@
+{{#if selected}}
+  {{selected}}
+{{else}}
+  {{placeholder}}
+{{/if}}

--- a/addon/templates/components/ui-autocomplete.hbs
+++ b/addon/templates/components/ui-autocomplete.hbs
@@ -1,0 +1,18 @@
+{{component fieldComponent id=componentId open="open" placeholder=placeholder
+  disabled=disabled value=value class="ff-autocomplete-field"}}
+
+{{#if isOpen}}
+  {{#if inline}}
+    {{#ui-option-list selectedValues=selectedValues items=items disabled=disabled on-select="selectItem"
+      close="close" set-aria-owns="setAriaOwns" set-active-descendent="setActiveDescendent" as |item|}}
+      {{yield item}}
+    {{/ui-option-list}}
+  {{else}}
+    {{#ember-tether target=componentSelector attachment=attachment targetAttachment=targetAttachment}}
+      {{#ui-option-list selectedValues=selectedValues items=items disabled=disabled on-select="selectItem"
+        close="close" set-aria-owns="setAriaOwns" set-active-descendent="setActiveDescendent" as |item|}}
+        {{yield item}}
+      {{/ui-option-list}}
+    {{/ember-tether}}
+  {{/if}}
+{{/if}}

--- a/app/components/ui-autocomplete-field.js
+++ b/app/components/ui-autocomplete-field.js
@@ -1,0 +1,1 @@
+export { default } from 'ui-autocomplete/components/ui-autocomplete-field';

--- a/app/components/ui-autocomplete.js
+++ b/app/components/ui-autocomplete.js
@@ -1,0 +1,1 @@
+export { default } from 'ui-autocomplete/components/ui-autocomplete';

--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "ui-autocomplete",
   "dependencies": {
-    "ember": "1.12.0",
+    "ember": "1.13.2",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.18",
+    "ember-data": "1.13.2",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
-    "ember-qunit": "0.3.3",
+    "ember-qunit": "0.4.0",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,35 +1,27 @@
 module.exports = {
-  scenarios: [
-    {
-      name: 'default',
-      dependencies: { }
+  scenarios: [{
+    name: 'ember-release',
+    dependencies: {
+      'ember': 'components/ember#release'
     },
-    {
-      name: 'ember-release',
-      dependencies: {
-        'ember': 'components/ember#release'
-      },
-      resolutions: {
-        'ember': 'release'
-      }
-    },
-    {
-      name: 'ember-beta',
-      dependencies: {
-        'ember': 'components/ember#beta'
-      },
-      resolutions: {
-        'ember': 'beta'
-      }
-    },
-    {
-      name: 'ember-canary',
-      dependencies: {
-        'ember': 'components/ember#canary'
-      },
-      resolutions: {
-        'ember': 'canary'
-      }
+    resolutions: {
+      'ember': 'release'
     }
-  ]
+  }, {
+    name: 'ember-beta',
+    dependencies: {
+      'ember': 'components/ember#beta'
+    },
+    resolutions: {
+      'ember': 'beta'
+    }
+  }, {
+    name: 'ember-canary',
+    dependencies: {
+      'ember': 'components/ember#canary'
+    },
+    resolutions: {
+      'ember': 'canary'
+    }
+  }]
 };

--- a/package.json
+++ b/package.json
@@ -23,22 +23,23 @@
     "ember-cli-app-version": "0.3.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
-    "ember-cli-htmlbars": "0.7.6",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.13",
     "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.0.0-beta.18",
+    "ember-data": "1.13.2",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-cli-htmlbars": "0.7.6",
+    "ui-option-list": "firefly-ui/ui-option-list"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/acceptance/autocomplete-test.js
+++ b/tests/acceptance/autocomplete-test.js
@@ -1,0 +1,121 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+
+const autocomplete = '#autocomplete';
+const autocompleteWithGroups = '#autocomplete-with-groups';
+
+const autocompleteField = '.ff-autocomplete-field';
+const firstOption = '.ff-option:first';
+const lastOption = '.ff-option:last';
+
+const tab = { keyCode: 9 };
+const moveDown = { keyCode: 40 };
+const moveUp = { keyCode: 38 };
+
+const enter = { keyCode: 13 };
+const escape = { keyCode: 27 };
+
+
+let application;
+
+module('Acceptance | autocomplete', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('selecting an option', function(assert) {
+  assert.expect(3);
+
+  return visit('/')
+    .then(() => {
+      return fillIn(`${autocomplete} ${autocompleteField}`, 'T');
+    })
+    .then(() => {
+      assert.equal(find(firstOption).text().trim(), 'Two');
+      assert.equal(find(lastOption).text().trim(), 'Three');
+      return click(lastOption);
+    })
+    .then(() => {
+      assert.equal(find(`${autocomplete} ${autocompleteField}`).val(), 'Three');
+    });
+});
+
+test('keyboard navigation', function(assert) {
+  assert.expect(3);
+
+  let focussed;
+
+  return visit('/')
+    .then(() => {
+      return fillIn(`${autocomplete} ${autocompleteField}`, 'T');
+    })
+    .then(() => {
+      focussed = find('.focussed');
+
+      assert.equal(focussed.text().trim(), 'Two');
+
+      Ember.$(`${autocomplete} ${autocompleteField}`).trigger(Ember.$.Event('keyup', moveDown));
+
+      focussed = find('.focussed');
+
+      assert.equal(focussed.text().trim(), 'Three');
+
+      Ember.$(`${autocomplete} ${autocompleteField}`).trigger(Ember.$.Event('keyup', enter));
+
+      assert.equal(find(`${autocomplete} ${autocompleteField}`).val(), 'Three');
+    });
+});
+
+test('option group keyboard navigation', function(assert) {
+  assert.expect(3);
+
+  let focussed;
+
+  return visit('/')
+    .then(() => {
+      return fillIn(`${autocompleteWithGroups} ${autocompleteField}`, 'e');
+    })
+    .then(() => {
+      focussed = find('.focussed');
+
+      assert.equal(focussed.text().trim(), 'New York');
+
+      Ember.$(`${autocompleteWithGroups} ${autocompleteField}`).trigger(Ember.$.Event('keyup', moveDown));
+
+      focussed = find('.focussed');
+
+      assert.equal(focussed.text().trim(), 'One');
+
+      Ember.$(`${autocompleteWithGroups} ${autocompleteField}`).trigger(Ember.$.Event('keyup', enter));
+
+      assert.equal(find(`${autocompleteWithGroups} ${autocompleteField}`).val(), 'One');
+    });
+});
+
+test('aria compatibility', function(assert) {
+  let focussed;
+  let autocompleteElement;
+
+  return visit('/')
+    .then(() => {
+      autocompleteElement = find(`${autocomplete}`);
+
+      assert.equal(autocompleteElement.attr('role'), 'combobox');
+      assert.equal(autocompleteElement.attr('aria-autocomplete'), 'list');
+      assert.equal(autocompleteElement.attr('aria-haspopup'), 'true');
+
+      return click(`${autocomplete} ${autocompleteField}`);
+    })
+    .then(() => {
+      assert.equal(autocompleteElement.attr('aria-expanded'), 'true');
+
+      focussed = find('.focussed');
+      assert.equal(autocompleteElement.attr('aria-activedescendant'), focussed.attr('id'));
+    });
+});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,84 @@
+import Ember from 'ember';
+
+const { computed } = Ember;
+
+export default Ember.Controller.extend({
+  options: Ember.A([{
+      label: 'One',
+      value: 1
+    }, {
+      label: 'Two',
+      value: 2
+    }, {
+      label: 'Three',
+      value: 3
+    }
+  ]),
+
+  filteredOptions: computed('options.@each', 'value', function(item) {
+    const regex = new RegExp(this.get('value'), 'i');
+
+    return Ember.A(this.get('options').filter((option) => {
+      return option.label.search(regex) > -1;
+    }));
+  }),
+
+  optionGroups: Ember.A([{
+    label: 'States',
+    items: Ember.A([{
+      label: 'California',
+      value: 'CA'
+    }, {
+      label: 'New York',
+      value: 'NY'
+    }, {
+      label: 'Washington',
+      value: 'WA'
+    }])
+  }, {
+    label: 'Numbers',
+    items: Ember.A([{
+      label: 'One',
+      value: 1
+    }, {
+      label: 'One Hundred and One',
+      value: 101
+    }, {
+      label: 'One Million',
+      value: 1000000
+    }])
+  }, {
+    label: 'People',
+    items: Ember.A([{
+      label: 'Bill Gates',
+      value: 'BG'
+    }, {
+      label: 'Steve Jobs',
+      value: 'SJ'
+    }])
+  }]),
+
+  filteredOptionGroups: computed('optionGroups.@each.items.@each', 'value', function() {
+    const regex = new RegExp(this.get('value'), 'i');
+
+    return this.get('optionGroups').map((group) => {
+      return {
+        label: group.label,
+        items: Ember.A(group.items.filter((option) => {
+          return option.label.search(regex) > -1;
+        }))
+      };
+    });
+  }),
+
+  actions: {
+    setValue(value) {
+      console.log('test');
+      this.set('value', value);
+    },
+
+    setValueManually(value) {
+      this.set('value', value);
+    }
+  }
+});

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,12 @@
+
+.ember-tether {
+  position: absolute;
+}
+
+.ff-option.focussed {
+  background-color: #CCC;
+}
+
+.ff-option.selected {
+  background-color: #AAA;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,20 @@
 <h2 id="title">Welcome to Ember.js</h2>
 
-{{outlet}}
+<div>
+  {{#ui-autocomplete id="autocomplete" placeholder="Select..." value=value on-select="setValue"
+    inline=true items=filteredOptions as |item|}}
+    {{#ui-option value=item.label}}
+      {{item.label}}
+    {{/ui-option}}
+  {{/ui-autocomplete}}
+</div>
+
+<div>
+  {{#ui-autocomplete id="autocomplete-with-groups" placeholder="Select..." value=value on-select="setValue" inline=true items=filteredOptionGroups as |group|}}
+    {{#ui-option-group label=group.label items=group.items as |item|}}
+      {{#ui-option value=item.label}}
+        {{item.label}}
+      {{/ui-option}}
+    {{/ui-option-group}}
+  {{/ui-autocomplete}}
+</div>


### PR DESCRIPTION
@twokul 

Usage:

```
{{#ui-autocomplete placeholder="Select..." value=value on-select="setValue" items=filteredOptions as |item|}}
  {{#ui-option value=item.label}}
    {{item.label}}
  {{/ui-option}}
{{/ui-autocomplete}}

{{#ui-autocomplete placeholder="Select..." value=value on-select="setValue" items=filteredOptionGroups as |group|}}
  {{#ui-option-group label=group.label items=group.items as |item|}}
    {{#ui-option value=item.label}}
      {{item.label}}
    {{/ui-option}}
  {{/ui-option-group}}
{{/ui-autocomplete}}
```

Notes:

* `value` is a two way binding to the value of the autocomplete text input. This is because the Ember text inputs still use two way binding, and attempting to send an action upwards on-change causes numerous errors. This will change once Ember inputs refactor to data-down-action-up.
* `items` should be a computed property consisting of the filtered options or option groups that you want to display in the autocomplete. The values should be dependent on `value` (i.e. `value` is the query).
* `on-select` will propagate the value of the selected item. This value will also be filled into the ui-autocomplete text input. Currently there isn't a way to propagate different date.

Feel free to modify according to your needs, I didn't push this yet because I felt the API may need to be fine-tuned. Ping me on Slack if you have questions.