### PR TITLE
Use observer instead

### DIFF
--- a/addon/components/ui-autocomplete.js
+++ b/addon/components/ui-autocomplete.js
@@ -84,11 +84,12 @@ export default Component.extend(OptionListAriaMixin, {
     }
   }),
 
-  value: computed({
-    set(key, value) {
-      this.set('query', value);
+  valueDidChange: observer('query', function() {
+    const value = this.get('value');
+    const query = this.get('query');
 
-      return value;
+    if (value !== query) {
+      this.set('query', value);
     }
   }),
 


### PR DESCRIPTION
changes `set` only computed to `alias` to avoid cases when one need to `get` computed